### PR TITLE
Use postgres instead of H2 database

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,10 @@
 # sonarqube-shellcheck
 
 Run Sonarqube in Docker with the shellcheck plugin
+
+### Note
+Start with:
+
+```
+sudo sysctl vm.max_map_count=262144 && docker-compose up
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,12 +2,22 @@
 version: "3.8"
 
 services:
+  postgres:
+    image: postgres:10
+    environment:
+      - POSTGRES_USER=sonar
+      - POSTGRES_PASSWORD=sonar
+    volumes:
+      - postgresql:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
   sonarqube:
     build: .
     ports:
       - 9000:9000
     environment:
-      - SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true
+      - sonar.jdbc.username=sonar
+      - sonar.jdbc.password=sonar
+      - sonar.jdbc.url=jdbc:postgresql://postgres:5432/sonar
     volumes:
       - conf:/opt/sonarqube/conf
       - data:/opt/sonarqube/data
@@ -16,10 +26,8 @@ services:
 
 volumes:
   conf:
-    driver: local
   data:
-    driver: local
   logs:
-    driver: local
   extensions:
-    driver: local
+  postgresql:
+  postgresql_data:


### PR DESCRIPTION
This makes it more "production-like", and we get rid of the
annoying warning about the H2 db.